### PR TITLE
Build docs with 'pre'

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 'min'
+          version: 'pre'
       - run: julia --project -e 'using Pkg; Pkg.develop([PackageSpec(path=joinpath(pwd(), "SnoopCompileCore"))])'
       - uses: julia-actions/julia-buildpkg@latest
       # To access the developer tools from within a package's environment, they should be in the default environment


### PR DESCRIPTION
'min' is not yet available. Long-term, we want 'min', but the documentation has never built in the JuliaDebug host, so we need at least one build to go through.

Fixes #433