### PR TITLE
Move PrettyTables to [weakdeps] and bump 3.1.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,13 @@
 name = "SnoopCompile"
 uuid = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"
 author = ["Tim Holy <tim.holy@gmail.com>", "Shuhei Kadowaki <aviatesk@gmail.com>"]
-version = "3.1.3"
+version = "3.1.4"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -18,6 +17,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 [weakdeps]
 Cthulhu = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 
 [extensions]


### PR DESCRIPTION
This fixes an error I was getting on Julia 1.10:
```julia
(@v1.10) pkg> activate --shared snoop_compile
  Activating new project at `~/.julia/environments/snoop_compile`

(@snoop_compile) pkg> add SnoopCompile@3.1.3
   Resolving package versions...
    Updating `~/.julia/environments/snoop_compile/Project.toml`
ERROR: KeyError: key "PrettyTables" not found
Stacktrace:
  [1] getindex
    @ ./dict.jl:498 [inlined]
...
```

